### PR TITLE
fix: correct spelling of bearer properties field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] Q2 2024
+
+Fixes:
+- Fixed error in bearer property parsing that caused bearers not to be reported
+
 ## [0.2.0] Q1 2024
 
 Features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "modemmanager"
 readme = "README.md"
 repository = "git@github.com:omnect/modemmanager.git"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 num = "0.4.1"

--- a/src/dbus/bearer.rs
+++ b/src/dbus/bearer.rs
@@ -105,7 +105,7 @@ impl TryFrom<Dict<'_, '_>> for Prop3Gpp {
             .ok_or(zbus::Error::InvalidField)?;
         let ip_type = MMBearerIpFamily::from_u32(ip_type).ok_or(zbus::Error::InvalidField)?;
         let apn_type: u32 = values
-            .get("apn_type")?
+            .get("apn-type")?
             .cloned()
             .ok_or(zbus::Error::InvalidField)?;
         let apn_type = MMBearerApnType::from_u32(apn_type).ok_or(zbus::Error::InvalidField)?;
@@ -158,7 +158,7 @@ impl TryFrom<Dict<'_, '_>> for Prop3Gpp {
             .ok_or(zbus::Error::InvalidField)?;
         let ip_type = MMBearerIpFamily::from_u32(ip_type).ok_or(zbus::Error::InvalidField)?;
         let apn_type: u32 = values
-            .get("apn_type")?
+            .get("apn-type")?
             .cloned()
             .ok_or(zbus::Error::InvalidField)?;
         let apn_type = MMBearerApnType::from_u32(apn_type).ok_or(zbus::Error::InvalidField)?;


### PR DESCRIPTION
One field type of the bearer properties was spelled wrong, which caused the bearer properties not to be reported correctly. With this commit we fix the spelling of the field name.